### PR TITLE
Kernel 6.x support for diskstats

### DIFF
--- a/includes/config.class.php
+++ b/includes/config.class.php
@@ -62,7 +62,7 @@ class config implements ArrayAccess, IteratorAggregate
 		}
 	}
 	
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		if (isset($this->vars[$offset]))
 		{
@@ -120,7 +120,7 @@ class config implements ArrayAccess, IteratorAggregate
 		return $this->offsetGet($offset);
 	}
 	
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		if (!isset($this->vars[$offset]))
 		{
@@ -141,7 +141,7 @@ class config implements ArrayAccess, IteratorAggregate
 		}
 	}
 	
-	public function getIterator()
+	public function getIterator(): Traversable
 	{
 		if (is_dir($this->dir))
 		{
@@ -166,12 +166,12 @@ class config implements ArrayAccess, IteratorAggregate
 		return new ArrayIterator($iteratorVars);
 	}
 	
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new Exception('Config may not be changed');
 	}
 	
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new Exception('Config may not be changed');
 	}

--- a/sources/disk.php
+++ b/sources/disk.php
@@ -105,7 +105,7 @@ class disk extends source implements source_rrd
 		$this->stats_part = array();
 		foreach ($lines as $line)
 		{
-			if (preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*$/i', $line, $parts))
+			if (preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*/i', $line, $parts))
 			{
 				$this->stats_disk = array(
 					/*
@@ -122,7 +122,7 @@ class disk extends source implements source_rrd
 					'ms_io_weighted' => $parts[11]*/
 				);
 			}
-			elseif ($this->withpartitions && preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '([0-9]*)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*$/i', $line, $parts))
+			elseif ($this->withpartitions && preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '([0-9]*)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*/i', $line, $parts))
 			{
 				$this->stats_part[$parts[1]] = array(
 					/*

--- a/sources/postgresql.php
+++ b/sources/postgresql.php
@@ -46,6 +46,7 @@ class postgresql extends source implements source_rrd
 	private $user;
 	private $password;
 	private $dbname;
+	private $db;
 	
 	private $backendworking;
 	private $backendwaiting;


### PR DESCRIPTION
This small change - not expect fixed number of entries in /proc/diskstats is necessary for newer kernel (6.1 in Debian Bookworm in my case).