### PR TITLE
make number diskstats entries not fixed - kernel 6.x

### DIFF
--- a/sources/disk.php
+++ b/sources/disk.php
@@ -105,7 +105,7 @@ class disk extends source implements source_rrd
 		$this->stats_part = array();
 		foreach ($lines as $line)
 		{
-			if (preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*$/i', $line, $parts))
+			if (preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*/i', $line, $parts))
 			{
 				$this->stats_disk = array(
 					/*
@@ -122,7 +122,7 @@ class disk extends source implements source_rrd
 					'ms_io_weighted' => $parts[11]*/
 				);
 			}
-			elseif ($this->withpartitions && preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '([0-9]*)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*$/i', $line, $parts))
+			elseif ($this->withpartitions && preg_match('/^\s*[0-9]+\s+[0-9]+\s+' . preg_quote($this->disk, '/') . '([0-9]*)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s*/i', $line, $parts))
 			{
 				$this->stats_part[$parts[1]] = array(
 					/*


### PR DESCRIPTION
This small change - not expect fixed number of entries in /proc/diskstats is necessary for newer kernel (6.1 in Debian Bookworm in my case).